### PR TITLE
Use github master version of pyxpcm

### DIFF
--- a/single-user-d4science/Dockerfile
+++ b/single-user-d4science/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install shortid \
         rdp \
         sentinelhub \
         import_ipynb \
-        pyxpcm \
+        git+https://github.com/obidam/pyxpcm.git \
         git+https://github.com/geopython/OWSLib.git
 
 RUN jupyter labextension disable @jupyterlab/filebrowser-extension:share-file


### PR DESCRIPTION
As requested by a Blue Cloud user, they need the latest version ( not yet released)

https://support.d4science.org/issues/19961