### PR TITLE
Add missing dependency of argopy

### DIFF
--- a/single-user-d4science/Dockerfile
+++ b/single-user-d4science/Dockerfile
@@ -7,6 +7,7 @@ RUN mamba install -y --quiet \
         catboost \
         netcdf4 \
         argopy \
+        aiohttp \
     && conda clean -tipsy
 
 RUN conda create --quiet --yes -n java8 \


### PR DESCRIPTION
Reported by BlueCloud (https://support.d4science.org/issues/19913), it comes from a missing dep in argopy( https://github.com/euroargodev/argopy/issues/59)