### PR TITLE
add client metadata to CS

### DIFF
--- a/single-user/Dockerfile
+++ b/single-user/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update \
     && curl https://dl.igtf.net/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-3 | apt-key add - \
     && apt-get update \
     && apt-get install -y ca-policy-egi-core \
+    && apt-get install -y git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -67,6 +68,13 @@ USER $NB_UID
 RUN mamba create --name dirac -y --quiet -c conda-forge ipython dirac-grid python=2.7 pypy2.7 ipykernel \
     && $(conda run -n dirac /bin/bash -c "which python") -m ipykernel install --prefix /tmp --name DIRAC \
     && jupyter kernelspec install /tmp/share/jupyter/kernels/dirac/ --name DIRAC --prefix /opt/conda \
+    && git clone -b rel-v7r2-pre16_tokens --single-branch https://github.com/TaykYoku/DIRAC.git /tmp/share/DIRAC \
+    && mv /tmp/share/DIRAC/FrameworkSystem/private/testNotebookAuth.py /opt/conda/envs/dirac/lib/python2.7/site-packages/DIRAC/FrameworkSystem/private/ \
+    && mv /tmp/share/DIRAC/FrameworkSystem/scripts/dirac-notebook-proxy-init.py /opt/conda/envs/dirac/bin/ \
+    && cp /opt/conda/envs/dirac/bin/dirac-notebook-proxy-init.py /opt/conda/envs/dirac/scripts/dirac-notebook-proxy-init \
+    && cp /opt/conda/envs/dirac/bin/dirac-notebook-proxy-init.py /opt/conda/envs/dirac/bin/dirac-notebook-proxy-init \
+    && chmod +x /opt/conda/envs/dirac/scripts/dirac-notebook-proxy-init \
+    && chmod +x /opt/conda/envs/dirac/bin/dirac-notebook-proxy-init \
     && rm -rf /tmp/share \
     && conda clean --all
 

--- a/single-user/dirac.cfg
+++ b/single-user/dirac.cfg
@@ -1,3 +1,15 @@
+LocalInstallation
+{ 
+  ConfigurationServerAPI = https://marosvn32.in2p3.fr/DIRAC/conf
+  AuthorizationClient
+  {
+    issuer = https://marosvn32.in2p3.fr/DIRAC/auth
+    authority = https://marosvn32.in2p3.fr/DIRAC/auth
+    client_id = 3f1DAj8z6eNw0E6JGq1VuzRkpWUL9XTxhL86efZwyV
+    redirect_uri = https://dirac.egi.eu
+    response_type = token 
+  }
+}
 DIRAC
 {
   Setup = EGI-Production


### PR DESCRIPTION
This RP adds some authorization client metadata to dirac.cfg to be used for authorization via DIRAC without a proxy.