### PR TITLE
add jupyterlab-system-monitor to show the CPU and MEM usage and limits

### DIFF
--- a/single-user-d4science/Dockerfile
+++ b/single-user-d4science/Dockerfile
@@ -18,8 +18,10 @@ RUN pip install shortid \
         rdp \
         sentinelhub \
         import_ipynb \
+        nbresuse \
         git+https://github.com/obidam/pyxpcm.git \
         git+https://github.com/geopython/OWSLib.git \
         git+https://github.com/euroargodev/argopy.git@master
 
+RUN jupyter labextension install jupyterlab-topbar-extension jupyterlab-system-monitor
 RUN jupyter labextension disable @jupyterlab/filebrowser-extension:share-file


### PR DESCRIPTION
Add jupyterlab-system-monitor extension to show the CPU and MEM usage and limits as requested by D4science/Sobigdata

It needs the option : _--NotebookApp.ResourceUseDisplay.track_cpu_percent=True_ to be added to the Spawner parameters.

tested at

https://d4science-dev-notebooks.fedcloud-tf.fedcloud.eu

