### PR TITLE
add PaNOSC and R-D4Science images 

### DIFF
--- a/single-user-panosc/Dockerfile
+++ b/single-user-panosc/Dockerfile
@@ -1,0 +1,16 @@
+FROM jupyter/minimal-notebook:ubuntu-18.04
+
+USER $NB_UID
+RUN conda install mamba -y --quiet -c conda-forge 
+RUN mamba install -y  -c onedata protobuf=3.13 fs.onedatafs && conda clean --all
+
+
+# packages not in conda
+RUN pip install git+https://github.com/EGI-Foundation/egi-notebooks-addons@0.1.3 \
+                h5glance \
+		nbtop \
+		tflearn \
+                shortid \
+                nbgitpuller 
+
+RUN rmdir work

--- a/single-user-r-d4science/Dockerfile
+++ b/single-user-r-d4science/Dockerfile
@@ -1,0 +1,16 @@
+FROM eginotebooks/base
+
+RUN mamba install -y --quiet \
+        r-rpostgres\
+        udunits2  \
+        r-rgdal\
+    && conda clean -tipsy
+
+RUN Rscript  -e "remotes::install_github('eblondel/geoflow', dependencies = c('Depends', 'Imports'))"
+
+RUN pip install shortid \
+        nbgitpuller \
+        import_ipynb \
+        nbresuse 
+
+RUN jupyter labextension disable @jupyterlab/filebrowser-extension:share-file


### PR DESCRIPTION
-  new PaNOSC image ( need new version of fs-onedatafs lib as we upgraded the cluster and it's not available for py38 )
-  new image for D4Science with dedicated R libraries ( to be included as a separate option in the profile list)

built manually for now